### PR TITLE
added ability to inspect each sample in the console

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A cross-platform application for viewing Enyo 2.0 samples from all its various l
 
 The app allows navigation through each library's samples.  Each sample is designed to be usable across all form factors, as a kind that can be rendered within the Sampler app, as well as standalone via the accompanying .html file.
 
+You can inspect the current sample through the console via `window.sample`.
+
 Since the app AJAX's in the JavaScript and CSS source files for the viewer, a few simple conventions must be followed to add new samples to the app:
 
 * The `assets/manifest.json` file defines the left-hand navigation hierarchy of the app:

--- a/source/App.js
+++ b/source/App.js
@@ -105,6 +105,7 @@ enyo.kind({
 			var kindNamespace = sample.ns || this.currNamespace;
 			var path = sample.path.substring(0, sample.path.lastIndexOf("/") + 1);
 			var instance = this.$.sampleContent.createComponent({kind:(kindNamespace + "." + kind)});
+			window.sample=instance;
 			this.$.sampleContent.render();
 			this.$.sampleContent.resized();
 			// Load the source code for the sample
@@ -155,6 +156,7 @@ enyo.kind({
 		this.$.cssContent.setContent("");
 		this.$.viewSource.hide();
 		this.$.openExternal.hide();
+		window.sample = undefined;
 	},
 	viewSource: function() {
 		this.$.contentPanels.setIndex(1);


### PR DESCRIPTION
small improvement (3 lines) sets `window.sample` to the current sample for easy inspection in the console.

Enyo-DCO-1.0-Signed-off-by: David Greisen dgreisen@gmail.com
