### PR TITLE
ENYO-900 and ENYO-901: Removing -webkit-overflow-scrolling CSS rule on Android-based platforms resolves overlow issues.

### DIFF
--- a/source/App.css
+++ b/source/App.css
@@ -1,5 +1,4 @@
 body {
-	-webkit-overflow-scrolling: touch;
 	font-family: 'Muli', 'Helvetica Neue', 'Nimbus Sans L', Arial, sans-serif;
 }
 button {


### PR DESCRIPTION
Enyo-DCO-1.0-Signed-off-by: Chris Patalano chris.patalano@palm.com
