### PR TITLE
Exclude .git dir when copying entire library in deploy.sh

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -88,6 +88,9 @@ for i in "$SOURCE/lib/"*; do
 	else
 		echo "Copying $o"
 		cp -r "$i" "$TARGET/lib"
+		if [ -e "$TARGET/lib/$o/.git" ]; then
+			rm -rf "$TARGET/lib/$o/.git"
+		fi
 	fi
 done
 


### PR DESCRIPTION
Similar to https://github.com/enyojs/enyo/pull/235 but sampler
has its own deploy.sh script which also needed this fix.
Deploy.bat should probably get a similar fix...

Enyo-DCO-1.1-Signed-off-by: Steve Lemke steve.lemke@palm.com
