### PR TITLE
Set currView to -1 when doing ViewStack.popAll

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -571,6 +571,7 @@ enyo.kind({
 		}
 	},
 	popAll: function() {
+		this.currView = -1;
 		this.saveAnimate = this.getAnimate();
 		this.setAnimate(false);
 		this.suppressFinish = true;


### PR DESCRIPTION
Sampler's ViewStack kind didn't correctly set the currView instance
variable to -1 when popping all views.  This didn't afffect the sampler
app, but could affect code that borrowed that kind for their own
implementation.

(bug reported and fix provided by jing-jing.li@hp.com)

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
