### PR TITLE
Fix manifest enyo location

### DIFF
--- a/assets/sampler-manifest.json
+++ b/assets/sampler-manifest.json
@@ -2,20 +2,20 @@
 	"sourcePath":"",
 	"name": "Enyo 2 Sampler",
 	"samples": [
-		{"name": "Enyo Core", "ns":"enyo.sample", "loadPackages":"$enyo/samples", "samples": [
-			{"name": "Platform", "path":"$enyo/samples/PlatformSample"},
+		{"name": "Enyo Core", "ns":"enyo.sample", "loadPackages":"enyo/samples", "samples": [
+			{"name": "Platform", "path":"enyo/samples/PlatformSample"},
 			{"name": "Ajax", "samples": [
-				{"name": "Ajax", "path":"$enyo/samples/AjaxSample"},
-				{"name": "JSON-P", "path":"$enyo/samples/JsonpSample"},
-				{"name": "WebService Component", "path":"$enyo/samples/WebServiceSample"}
+				{"name": "Ajax", "path":"enyo/samples/AjaxSample"},
+				{"name": "JSON-P", "path":"enyo/samples/JsonpSample"},
+				{"name": "WebService Component", "path":"enyo/samples/WebServiceSample"}
 			]},
-			{"name": "Scroller", "path":"$enyo/samples/ScrollerSample"},
-			{"name": "Repeater", "path":"$enyo/samples/RepeaterSample"},
-			{"name": "Gestures", "path":"$enyo/samples/GestureSample"},
-			{"name": "Drawer", "path":"$enyo/samples/DrawerSample"},
-			{"name": "DataRepeater", "path":"$enyo/samples/DataRepeaterSample"},
-			{"name": "DataList", "path":"$enyo/samples/DataListSample"},
-			{"name": "DataGridList", "path":"$enyo/samples/DataGridListSample"}
+			{"name": "Scroller", "path":"enyo/samples/ScrollerSample"},
+			{"name": "Repeater", "path":"enyo/samples/RepeaterSample"},
+			{"name": "Gestures", "path":"enyo/samples/GestureSample"},
+			{"name": "Drawer", "path":"enyo/samples/DrawerSample"},
+			{"name": "DataRepeater", "path":"enyo/samples/DataRepeaterSample"},
+			{"name": "DataList", "path":"enyo/samples/DataListSample"},
+			{"name": "DataGridList", "path":"enyo/samples/DataGridListSample"}
 		]},
 		{"name": "Onyx", "ns":"onyx.sample", "loadPackages":"$lib/onyx $lib/onyx/samples", "samples": [
 			{"name": "Toolbars", "path":"$lib/onyx/samples/ToolbarSample", "css":"sample"},

--- a/source/App.js
+++ b/source/App.js
@@ -43,9 +43,9 @@ enyo.kind({
 		this.resized();
 	},
 	updateExternalTools: function() {
-		var showExternalToosl = this.debug || 
-			(document.location.protocol != "file:" && 
-			document.location.protocol != "x-wmapp0:" && 
+		var showExternalToosl = this.debug ||
+			(document.location.protocol != "file:" &&
+			document.location.protocol != "x-wmapp0:" &&
 			document.location.protocol != "ms-appx:");
 		this.$.fiddleDecorator.setShowing(showExternalToosl);
 		this.$.openExternalDecorator.setShowing(showExternalToosl);
@@ -57,7 +57,7 @@ enyo.kind({
 		if (this.preloadedManifest) {
 			this.processSamples(this.preloadedManifest);
 		} else {
-			new enyo.Ajax({url: "assets/manifest.json", mimeType: "application/json"})
+			new enyo.Ajax({url: "assets/sampler-manifest.json", mimeType: "application/json"})
 				.response(this.bindSafely(function(inSender, inSamples) {
 					this.processSamples(inSamples);
 				}))


### PR DESCRIPTION
Due to changes in the deploy method, we no longer copy enyo samples
and source into the build folder. This changes the manifest.json file
to use just "enyo" instead of "$enyo" which lets the app look in the
proper location, since $enyo points into the build folder where the
minified enyo.js lives.

We also rename manifest.json to sampler-manifest.json. This is for
eventual packaging of Sampler as a Chrome Store app, as having multiple
manifest.json files in the app tree causes that packager to fail.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
