### PR TITLE
Add manifest file for Firefox OS

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,0 +1,13 @@
+{
+  "name": "Enyo 2 Sampler",
+  "description": "showing UI features of Enyo and its libraries",
+  "launch_path": "/index.html",
+  "icons": {
+    "128": "/icon.png"
+  },
+  "developer": {
+    "name": "Enyo JS Framework",
+    "url": "http://enyojs.com"
+  },
+  "default_locale": "en"
+}


### PR DESCRIPTION
The built version of sampler can run on FxOS if we provide
a manifest.webapp file in the root. This is a basic one
based on the documentation samples.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
