### PR TITLE
ENYO-3889: Prevent unintended focusing of input field after tap.

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -221,6 +221,7 @@ enyo.kind({
 				this.$.mainPanels.next();
 			}
 		}
+		inEvent.preventDefault();
 	},
 	renderSample: function(sample) {
 		// Create a new sample kind instance inside sampleContent


### PR DESCRIPTION
## Issue

On mobile devices, when loading one of the AJAX samples under Enyo Core, the second input field automatically receives focus. This is caused by an issue where the location of the tap that loads the sample propagates forward to the loaded sample, which happens to be the location of the second input field.
## Fix

We call `preventDefault` on the navigation tap event.
## Notes

This is only a sampler-specific patch that does not address the underlying issue. That will be addressed in a separate PR in the event that a fix needs to be made before a general solution can be found.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
