### PR TITLE
BHV-2574: Fixes to allow sampler to build as webOS app:

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -1,0 +1,27 @@
+{
+	"id": "com.enyojs.enyo2sampler",
+	"version": "0.0.3",
+	"vendor": "LGE",
+	"type": "web",
+	"main": "index.html",
+	"title": "Enyo 2 Sampler",
+	"icon": "icon.png",
+	"iconColor": "#ffffff",
+	"transparent": false,
+	"visible": true,
+	"uiRevision": 2,
+	"class": {
+		"hidden": false
+	},
+	"xonDeviceSource": {
+		"enyo":                 "$enyo-framework/2.4.0/enyo",
+		"lib/layout":           "$enyo-framework/2.4.0/lib/layout",
+		"lib/moonstone":        "$enyo-framework/2.4.0/lib/moonstone",
+		"lib/spotlight":        "$enyo-framework/2.4.0/lib/spotlight",
+		"lib/enyo-webos":       "$enyo-framework/2.4.0/lib/enyo-webos",
+		"lib/enyo-ilib":        "$enyo-framework/2.4.0/lib/enyo-ilib"
+	},
+	"enyoVersion": "2.4.0",
+	"containerJS": "build/app1.js",
+	"containerCSS": "build/app1.css"
+}

--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -2,179 +2,179 @@
 	"sourcePath":"",
 	"name": "Enyo 2 Sampler",
 	"samples": [
-		{"name": "Enyo Core", "ns":"enyo.sample", "loadPackages":"$enyo/samples", "samples": [
-			{"name": "Platform", "path":"$enyo/samples/PlatformSample"},
+		{"name": "Enyo Core", "ns":"enyo.sample", "loadPackages":"enyo/samples", "samples": [
+			{"name": "Platform", "path":"enyo/samples/PlatformSample"},
 			{"name": "Ajax", "samples": [
-				{"name": "Ajax", "path":"$enyo/samples/AjaxSample"},
-				{"name": "JSON-P", "path":"$enyo/samples/JsonpSample"},
-				{"name": "WebService Component", "path":"$enyo/samples/WebServiceSample"}
+				{"name": "Ajax", "path":"enyo/samples/AjaxSample"},
+				{"name": "JSON-P", "path":"enyo/samples/JsonpSample"},
+				{"name": "WebService Component", "path":"enyo/samples/WebServiceSample"}
 			]},
-			{"name": "Scroller", "path":"$enyo/samples/ScrollerSample"},
-			{"name": "Gestures", "path":"$enyo/samples/GestureSample"},
+			{"name": "Scroller", "path":"enyo/samples/ScrollerSample"},
+			{"name": "Gestures", "path":"enyo/samples/GestureSample"},
 			{"name": "UI", "samples": [
-				{"name": "Anchor", "path":"$enyo/samples/AnchorSample"},
-				{"name": "Animator", "path":"$enyo/samples/AnimatorSample"},
-				{"name": "Audio", "path":"$enyo/samples/AudioSample"},
-				{"name": "Button", "path":"$enyo/samples/ButtonSample"},
-				{"name": "Checkbox", "path":"$enyo/samples/CheckboxSample"},
-				{"name": "DataRepeater", "path":"$enyo/samples/DataRepeaterSample"},
-				{"name": "DataList", "path":"$enyo/samples/DataListSample"},
-				{"name": "DataGridList", "path":"$enyo/samples/DataGridListSample"},
-				{"name": "DragAvatar", "path":"$enyo/samples/DragAvatarSample"},
-				{"name": "Drawer", "path":"$enyo/samples/DrawerSample"},
-				{"name": "Grouping", "path":"$enyo/samples/GroupSample"},
-				{"name": "Image", "path":"$enyo/samples/ImageSample"},
-				{"name": "Input", "path":"$enyo/samples/InputSample"},
-				{"name": "Popup", "path":"$enyo/samples/PopupSample"},
-				{"name": "Repeater", "path":"$enyo/samples/RepeaterSample"},
-				{"name": "RichText", "path":"$enyo/samples/RichTextSample"},
-				{"name": "Select Lists", "path":"$enyo/samples/SelectSample"},
-				{"name": "Table", "path":"$enyo/samples/TableSample"},
-				{"name": "TextArea", "path":"$enyo/samples/TextAreaSample"},
-				{"name": "Video", "path":"$enyo/samples/VideoSample"}
+				{"name": "Anchor", "path":"enyo/samples/AnchorSample"},
+				{"name": "Animator", "path":"enyo/samples/AnimatorSample"},
+				{"name": "Audio", "path":"enyo/samples/AudioSample"},
+				{"name": "Button", "path":"enyo/samples/ButtonSample"},
+				{"name": "Checkbox", "path":"enyo/samples/CheckboxSample"},
+				{"name": "DataRepeater", "path":"enyo/samples/DataRepeaterSample"},
+				{"name": "DataList", "path":"enyo/samples/DataListSample"},
+				{"name": "DataGridList", "path":"enyo/samples/DataGridListSample"},
+				{"name": "DragAvatar", "path":"enyo/samples/DragAvatarSample"},
+				{"name": "Drawer", "path":"enyo/samples/DrawerSample"},
+				{"name": "Grouping", "path":"enyo/samples/GroupSample"},
+				{"name": "Image", "path":"enyo/samples/ImageSample"},
+				{"name": "Input", "path":"enyo/samples/InputSample"},
+				{"name": "Popup", "path":"enyo/samples/PopupSample"},
+				{"name": "Repeater", "path":"enyo/samples/RepeaterSample"},
+				{"name": "RichText", "path":"enyo/samples/RichTextSample"},
+				{"name": "Select Lists", "path":"enyo/samples/SelectSample"},
+				{"name": "Table", "path":"enyo/samples/TableSample"},
+				{"name": "TextArea", "path":"enyo/samples/TextAreaSample"},
+				{"name": "Video", "path":"enyo/samples/VideoSample"}
 			]}
 		]},
-		{"name": "Layout", "ns":"enyo.sample", "loadPackages":"$lib/layout", "samples": [
-			{"name": "Fittable Layouts", "loadPackages":"$lib/layout/fittable/samples", "samples": [
-				{"name": "Basic sample", "path":"$lib/layout/fittable/samples/FittableSample", "css":"sample"},
-				{"name": "Details", "path":"$lib/layout/fittable/samples/FittableDescription", "css":"sample"},
-				{"name": "Example app layout 1", "path":"$lib/layout/fittable/samples/FittableAppLayout1", "css":"sample"},
-				{"name": "Example app layout 2", "path":"$lib/layout/fittable/samples/FittableAppLayout2", "css":"sample"},
-				{"name": "Example app layout 3", "path":"$lib/layout/fittable/samples/FittableAppLayout3", "css":"sample"},
-				{"name": "Example app layout 4", "path":"$lib/layout/fittable/samples/FittableAppLayout4", "css":"sample"}
+		{"name": "Layout", "ns":"enyo.sample", "loadPackages":"lib/layout", "samples": [
+			{"name": "Fittable Layouts", "loadPackages":"lib/layout/fittable/samples", "samples": [
+				{"name": "Basic sample", "path":"lib/layout/fittable/samples/FittableSample", "css":"sample"},
+				{"name": "Details", "path":"lib/layout/fittable/samples/FittableDescription", "css":"sample"},
+				{"name": "Example app layout 1", "path":"lib/layout/fittable/samples/FittableAppLayout1", "css":"sample"},
+				{"name": "Example app layout 2", "path":"lib/layout/fittable/samples/FittableAppLayout2", "css":"sample"},
+				{"name": "Example app layout 3", "path":"lib/layout/fittable/samples/FittableAppLayout3", "css":"sample"},
+				{"name": "Example app layout 4", "path":"lib/layout/fittable/samples/FittableAppLayout4", "css":"sample"}
 			]},
-			{"name": "List", "ns":"enyo.sample", "loadPackages":"$lib/layout/list/samples", "samples": [
-				{"name": "Basic list", "path":"$lib/layout/list/samples/ListBasicSample"},
-				{"name": "Pulldown list (Flickr)", "path":"$lib/layout/list/samples/ListPulldownSample"},
-				{"name": "Lazy-loading list (Flickr)", "path":"$lib/layout/panels/samples/PanelsFlickrSample"},
-				{"name": "Editable list (Contacts)", "path":"$lib/layout/list/samples/ListContactsSample"},
-				{"name": "Around list", "path":"$lib/layout/list/samples/ListAroundSample"},
-				{"name": "Swipeable-Reorderable list", "path":"$lib/layout/list/samples/ListLanguagesSample"}
+			{"name": "List", "ns":"enyo.sample", "loadPackages":"lib/layout/list/samples", "samples": [
+				{"name": "Basic list", "path":"lib/layout/list/samples/ListBasicSample"},
+				{"name": "Pulldown list (Flickr)", "path":"lib/layout/list/samples/ListPulldownSample"},
+				{"name": "Lazy-loading list (Flickr)", "path":"lib/layout/panels/samples/PanelsFlickrSample"},
+				{"name": "Editable list (Contacts)", "path":"lib/layout/list/samples/ListContactsSample"},
+				{"name": "Around list", "path":"lib/layout/list/samples/ListAroundSample"},
+				{"name": "Swipeable-Reorderable list", "path":"lib/layout/list/samples/ListLanguagesSample"}
 			]},
-			{"name": "Panels", "ns":"enyo.sample", "loadPackages":"$lib/layout/panels/samples", "samples": [
-				{"name": "Arranger sampler", "path":"$lib/layout/panels/samples/PanelsSample"},
-				{"name": "Sliding app example", "path":"$lib/layout/panels/samples/PanelsSlidingSample"},
-				{"name": "Flickr app example", "path":"$lib/layout/panels/samples/PanelsFlickrSample"}
+			{"name": "Panels", "ns":"enyo.sample", "loadPackages":"lib/layout/panels/samples", "samples": [
+				{"name": "Arranger sampler", "path":"lib/layout/panels/samples/PanelsSample"},
+				{"name": "Sliding app example", "path":"lib/layout/panels/samples/PanelsSlidingSample"},
+				{"name": "Flickr app example", "path":"lib/layout/panels/samples/PanelsFlickrSample"}
 			]},
-			{"name": "Tree", "ns":"enyo.sample", "loadPackages":"$lib/layout/tree/samples", "path":"$lib/layout/tree/samples/TreeSample"},
-			{"name": "Image View", "loadPackages":"$lib/layout/imageview/samples", "path":"$lib/layout/imageview/samples/ImageViewSample"},
-			{"name": "Image Carousel", "loadPackages":"$lib/layout/imageview/samples", "path":"$lib/layout/imageview/samples/ImageCarouselSample"}
+			{"name": "Tree", "ns":"enyo.sample", "loadPackages":"lib/layout/tree/samples", "path":"lib/layout/tree/samples/TreeSample"},
+			{"name": "Image View", "loadPackages":"lib/layout/imageview/samples", "path":"lib/layout/imageview/samples/ImageViewSample"},
+			{"name": "Image Carousel", "loadPackages":"lib/layout/imageview/samples", "path":"lib/layout/imageview/samples/ImageCarouselSample"}
 		]},
-		{"name": "Onyx UI", "ns":"onyx.sample", "loadPackages":"$lib/onyx $lib/onyx/samples", "samples": [
-			{"name": "Toolbars", "path":"$lib/onyx/samples/ToolbarSample", "css":"sample"},
-			{"name": "Basic Buttons", "path":"$lib/onyx/samples/ButtonSample", "css":"sample"},
-			{"name": "Grouped Buttons", "path":"$lib/onyx/samples/ButtonGroupSample", "css":"sample"},
-			{"name": "Icon Buttons", "path":"$lib/onyx/samples/IconButtonSample", "css":"sample"},
-			{"name": "Toggle Buttons", "path":"$lib/onyx/samples/ToggleButtonSample", "css":"sample"},
-			{"name": "Checkboxes", "path":"$lib/onyx/samples/CheckboxSample", "css":"sample"},
-			{"name": "Inputs", "path":"$lib/onyx/samples/InputSample", "css":"sample"},
-			{"name": "Group Boxes", "path":"$lib/onyx/samples/GroupboxSample", "css":"sample"},
-			{"name": "Progress Bars", "path":"$lib/onyx/samples/ProgressSample", "css":"sample"},
-			{"name": "Sliders", "path":"$lib/onyx/samples/SliderSample", "css":"sample"},
-			{"name": "Menus", "path":"$lib/onyx/samples/MenuSample", "css":"sample"},
-			{"name": "Pickers", "path":"$lib/onyx/samples/PickerSample", "css":"sample"},
-			{"name": "DatePicker", "path":"$lib/onyx/samples/DatePickerSample", "css":"sample"},
-			{"name": "TimePicker", "path":"$lib/onyx/samples/TimePickerSample", "css":"sample"},
-			{"name": "Tooltips", "path":"$lib/onyx/samples/TooltipSample", "css":"sample"},
-			{"name": "Spinners", "path":"$lib/onyx/samples/SpinnerSample", "css":"sample"},
-			{"name": "Popups", "path":"$lib/onyx/samples/PopupSample", "css":"sample"},
-			{"name": "ContextualPopups", "path":"$lib/onyx/samples/ContextualPopupSample", "css":"sample"}
+		{"name": "Onyx UI", "ns":"onyx.sample", "loadPackages":"lib/onyx lib/onyx/samples", "samples": [
+			{"name": "Toolbars", "path":"lib/onyx/samples/ToolbarSample", "css":"sample"},
+			{"name": "Basic Buttons", "path":"lib/onyx/samples/ButtonSample", "css":"sample"},
+			{"name": "Grouped Buttons", "path":"lib/onyx/samples/ButtonGroupSample", "css":"sample"},
+			{"name": "Icon Buttons", "path":"lib/onyx/samples/IconButtonSample", "css":"sample"},
+			{"name": "Toggle Buttons", "path":"lib/onyx/samples/ToggleButtonSample", "css":"sample"},
+			{"name": "Checkboxes", "path":"lib/onyx/samples/CheckboxSample", "css":"sample"},
+			{"name": "Inputs", "path":"lib/onyx/samples/InputSample", "css":"sample"},
+			{"name": "Group Boxes", "path":"lib/onyx/samples/GroupboxSample", "css":"sample"},
+			{"name": "Progress Bars", "path":"lib/onyx/samples/ProgressSample", "css":"sample"},
+			{"name": "Sliders", "path":"lib/onyx/samples/SliderSample", "css":"sample"},
+			{"name": "Menus", "path":"lib/onyx/samples/MenuSample", "css":"sample"},
+			{"name": "Pickers", "path":"lib/onyx/samples/PickerSample", "css":"sample"},
+			{"name": "DatePicker", "path":"lib/onyx/samples/DatePickerSample", "css":"sample"},
+			{"name": "TimePicker", "path":"lib/onyx/samples/TimePickerSample", "css":"sample"},
+			{"name": "Tooltips", "path":"lib/onyx/samples/TooltipSample", "css":"sample"},
+			{"name": "Spinners", "path":"lib/onyx/samples/SpinnerSample", "css":"sample"},
+			{"name": "Popups", "path":"lib/onyx/samples/PopupSample", "css":"sample"},
+			{"name": "ContextualPopups", "path":"lib/onyx/samples/ContextualPopupSample", "css":"sample"}
 		]},
 		{"name": "Moonstone UI", "ns": "moon.sample", "samples": [
-			{"name": "Accordion", "path":"$lib/moonstone/samples/AccordionSample", "css":"sample"},
+			{"name": "Accordion", "path":"lib/moonstone/samples/AccordionSample", "css":"sample"},
 			{"name": "Buttons", "samples": [
-				{"name": "Button", "path":"$lib/moonstone/samples/ButtonSample"},
-				{"name": "Toggle Button", "path":"$lib/moonstone/samples/ToggleButtonSample"},
-				{"name": "Icon Button", "path":"$lib/moonstone/samples/IconButtonSample"}
+				{"name": "Button", "path":"lib/moonstone/samples/ButtonSample"},
+				{"name": "Toggle Button", "path":"lib/moonstone/samples/ToggleButtonSample"},
+				{"name": "Icon Button", "path":"lib/moonstone/samples/IconButtonSample"}
 			]},
-			{"name": "Clock", "path":"$lib/moonstone/samples/ClockSample"},
-			{"name": "Divider", "path":"$lib/moonstone/samples/DividerSample"},
-			{"name": "Drawer", "path":"$lib/moonstone/samples/DrawerSample"},
-			{"name": "Fonts", "path":"$lib/moonstone/samples/FontSample"},
-			{"name": "Form Checkbox", "path":"$lib/moonstone/samples/FormCheckboxSample"},
+			{"name": "Clock", "path":"lib/moonstone/samples/ClockSample"},
+			{"name": "Divider", "path":"lib/moonstone/samples/DividerSample"},
+			{"name": "Drawer", "path":"lib/moonstone/samples/DrawerSample"},
+			{"name": "Fonts", "path":"lib/moonstone/samples/FontSample"},
+			{"name": "Form Checkbox", "path":"lib/moonstone/samples/FormCheckboxSample"},
 			{"name": "Headers", "samples": [
-				{"name": "Header", "path":"$lib/moonstone/samples/HeaderSample"},
-				{"name": "Input Header", "path":"$lib/moonstone/samples/InputHeaderSample"},
-				{"name": "Auto-collapsing Header", "path":"$lib/moonstone/samples/HeaderAutoCollapsingSample"}
+				{"name": "Header", "path":"lib/moonstone/samples/HeaderSample"},
+				{"name": "Input Header", "path":"lib/moonstone/samples/InputHeaderSample"},
+				{"name": "Auto-collapsing Header", "path":"lib/moonstone/samples/HeaderAutoCollapsingSample"}
 			]},
-			{"name": "Icon", "path":"$lib/moonstone/samples/IconSample"},
-			{"name": "Icon Button", "path":"$lib/moonstone/samples/IconButtonSample"},
-			{"name": "Image Badge", "path":"$lib/moonstone/samples/ImageBadgeSample"},
+			{"name": "Icon", "path":"lib/moonstone/samples/IconSample"},
+			{"name": "Icon Button", "path":"lib/moonstone/samples/IconButtonSample"},
+			{"name": "Image Badge", "path":"lib/moonstone/samples/ImageBadgeSample"},
 			{"name": "Inputs", "samples": [
-				{"name": "Basic Inputs", "path":"$lib/moonstone/samples/InputSample"},
-				{"name": "Expandable Input", "path":"$lib/moonstone/samples/ExpandableInputSample"},
-				{"name": "Input Header", "path":"$lib/moonstone/samples/InputHeaderSample"}
+				{"name": "Basic Inputs", "path":"lib/moonstone/samples/InputSample"},
+				{"name": "Expandable Input", "path":"lib/moonstone/samples/ExpandableInputSample"},
+				{"name": "Input Header", "path":"lib/moonstone/samples/InputHeaderSample"}
 			]},
 			{"name": "Items", "samples": [
-				{"name": "Basic Item", "path":"$lib/moonstone/samples/ItemSample"},
-				{"name": "Selectable Item", "path":"$lib/moonstone/samples/SelectableItemSample"},
-				{"name": "Radio Item", "path":"$lib/moonstone/samples/RadioItemSample"},
-				{"name": "Checkbox Item", "path":"$lib/moonstone/samples/CheckboxItemSample"},
-				{"name": "Toggle Item", "path":"$lib/moonstone/samples/ToggleItemSample"}
+				{"name": "Basic Item", "path":"lib/moonstone/samples/ItemSample"},
+				{"name": "Selectable Item", "path":"lib/moonstone/samples/SelectableItemSample"},
+				{"name": "Radio Item", "path":"lib/moonstone/samples/RadioItemSample"},
+				{"name": "Checkbox Item", "path":"lib/moonstone/samples/CheckboxItemSample"},
+				{"name": "Toggle Item", "path":"lib/moonstone/samples/ToggleItemSample"}
 			]},
 			{"name": "List", "samples": [
 				{"name": "List Items", "samples": [
-					{"name": "Labeled Text Item", "path":"$lib/moonstone/samples/LabeledTextItemSample"},
-					{"name": "Image Item", "path":"$lib/moonstone/samples/ImageItemSample"}
+					{"name": "Labeled Text Item", "path":"lib/moonstone/samples/LabeledTextItemSample"},
+					{"name": "Image Item", "path":"lib/moonstone/samples/ImageItemSample"}
 				]},
-				{"name": "Data List", "path":"$lib/moonstone/samples/DataListSample", "css":"sample"},
-				{"name": "Data Grid List", "path":"$lib/moonstone/samples/DataGridListSample", "css":"sample"}
+				{"name": "Data List", "path":"lib/moonstone/samples/DataListSample", "css":"sample"},
+				{"name": "Data Grid List", "path":"lib/moonstone/samples/DataGridListSample", "css":"sample"}
 			]},
-			{"name": "List Actions", "path":"$lib/moonstone/samples/ListActionsSample"},
+			{"name": "List Actions", "path":"lib/moonstone/samples/ListActionsSample"},
 			{"name": "Media", "samples": [
-				{"name": "Fullscreen Video Player", "path":"$lib/moonstone/samples/VideoPlayerSample"},
-				{"name": "Inline Video Player", "path":"$lib/moonstone/samples/PanelsVideoPlayerSample"},
-				{"name": "Always Viewing Panels with Video", "path":"$lib/moonstone/samples/AlwaysViewingPanelsWithVideoSample"},
-				{"name": "Activity Panels with Video", "path":"$lib/moonstone/samples/ActivityPanelsWithVideoSample"}
+				{"name": "Fullscreen Video Player", "path":"lib/moonstone/samples/VideoPlayerSample"},
+				{"name": "Inline Video Player", "path":"lib/moonstone/samples/PanelsVideoPlayerSample"},
+				{"name": "Always Viewing Panels with Video", "path":"lib/moonstone/samples/AlwaysViewingPanelsWithVideoSample"},
+				{"name": "Activity Panels with Video", "path":"lib/moonstone/samples/ActivityPanelsWithVideoSample"}
 			]},
 			{"name": "Object Actions", "samples": [
-				{"name": "Horizontal Object Actions", "path":"$lib/moonstone/samples/ObjectActionHorizontalTypeSample"},
-				{"name": "Vertical Object Actions", "path":"$lib/moonstone/samples/ObjectActionVerticalTypeSample"}
+				{"name": "Horizontal Object Actions", "path":"lib/moonstone/samples/ObjectActionHorizontalTypeSample"},
+				{"name": "Vertical Object Actions", "path":"lib/moonstone/samples/ObjectActionVerticalTypeSample"}
 			]},
 			{"name": "Panels", "samples": [
-				{"name": "Always Viewing Pattern", "path":"$lib/moonstone/samples/AlwaysViewingPanelsSample"},
-				{"name": "Activity Pattern", "path":"$lib/moonstone/samples/ActivityPanelsSample"},
-				{"name": "Card Arranger", "path":"$lib/moonstone/samples/PanelsWithCardArrangerSample"},
-				{"name": "Carousel Arranger", "path":"$lib/moonstone/samples/PanelsWithCarouselArrangerSample"},
-				{"name": "Dynamic Panels Push/Pop", "path":"$lib/moonstone/samples/DynamicPanelsSample"}
+				{"name": "Always Viewing Pattern", "path":"lib/moonstone/samples/AlwaysViewingPanelsSample"},
+				{"name": "Activity Pattern", "path":"lib/moonstone/samples/ActivityPanelsSample"},
+				{"name": "Card Arranger", "path":"lib/moonstone/samples/PanelsWithCardArrangerSample"},
+				{"name": "Carousel Arranger", "path":"lib/moonstone/samples/PanelsWithCarouselArrangerSample"},
+				{"name": "Dynamic Panels Push/Pop", "path":"lib/moonstone/samples/DynamicPanelsSample"}
 			]},
 			{"name": "Pickers", "samples": [
-				{"name": "Expandable Picker", "path":"$lib/moonstone/samples/ExpandablePickerSample"},
-				{"name": "Simple Picker", "path":"$lib/moonstone/samples/SimplePickerSample", "css":"sample"},
-				{"name": "Date Picker", "path":"$lib/moonstone/samples/DatePickerSample"},
-				{"name": "Time Picker", "path":"$lib/moonstone/samples/TimePickerSample", "css":"sample"},
-				{"name": "Integer Picker", "path":"$lib/moonstone/samples/IntegerPickerSample"},
-				{"name": "Calendar", "path":"$lib/moonstone/samples/CalendarSample"}
+				{"name": "Expandable Picker", "path":"lib/moonstone/samples/ExpandablePickerSample"},
+				{"name": "Simple Picker", "path":"lib/moonstone/samples/SimplePickerSample", "css":"sample"},
+				{"name": "Date Picker", "path":"lib/moonstone/samples/DatePickerSample"},
+				{"name": "Time Picker", "path":"lib/moonstone/samples/TimePickerSample", "css":"sample"},
+				{"name": "Integer Picker", "path":"lib/moonstone/samples/IntegerPickerSample"},
+				{"name": "Calendar", "path":"lib/moonstone/samples/CalendarSample"}
 			]},
 			{"name": "Popups", "samples": [
-				{"name": "Basic Popup", "path":"$lib/moonstone/samples/PopupSample", "css":"sample"},
-				{"name": "Dialog Popup", "path":"$lib/moonstone/samples/DialogSample", "css":"sample"},
-				{"name": "Contextual Popup", "path":"$lib/moonstone/samples/ContextualPopupSample"}
+				{"name": "Basic Popup", "path":"lib/moonstone/samples/PopupSample", "css":"sample"},
+				{"name": "Dialog Popup", "path":"lib/moonstone/samples/DialogSample", "css":"sample"},
+				{"name": "Contextual Popup", "path":"lib/moonstone/samples/ContextualPopupSample"}
 			]},
-			{"name": "Progress Bar", "path":"$lib/moonstone/samples/ProgressSample"},
+			{"name": "Progress Bar", "path":"lib/moonstone/samples/ProgressSample"},
 			{"name": "Scroller", "samples": [
-				{"name": "Horizontal Scroller", "path":"$lib/moonstone/samples/ScrollerHorizontalSample"},
-				{"name": "Vertical Scroller", "path":"$lib/moonstone/samples/ScrollerVerticalSample"},
-				{"name": "2D Scroller", "path":"$lib/moonstone/samples/Scroller2dSample"},
-				{"name": "Text Scroller", "path":"$lib/moonstone/samples/ScrollerTextSample"}
+				{"name": "Horizontal Scroller", "path":"lib/moonstone/samples/ScrollerHorizontalSample"},
+				{"name": "Vertical Scroller", "path":"lib/moonstone/samples/ScrollerVerticalSample"},
+				{"name": "2D Scroller", "path":"lib/moonstone/samples/Scroller2dSample"},
+				{"name": "Text Scroller", "path":"lib/moonstone/samples/ScrollerTextSample"}
 			]},
-			{"name": "Slider", "path":"$lib/moonstone/samples/SliderSample"},
-			{"name": "Spinner", "path":"$lib/moonstone/samples/SpinnerSample"},
+			{"name": "Slider", "path":"lib/moonstone/samples/SliderSample"},
+			{"name": "Spinner", "path":"lib/moonstone/samples/SpinnerSample"},
 			{"name": "Text", "samples": [
-				{"name": "Body Text", "path":"$lib/moonstone/samples/BodyTextSample"},
-				{"name": "Expandable Text", "path":"$lib/moonstone/samples/ExpandableTextSample"}
+				{"name": "Body Text", "path":"lib/moonstone/samples/BodyTextSample"},
+				{"name": "Expandable Text", "path":"lib/moonstone/samples/ExpandableTextSample"}
 			]},
-			{"name": "Tooltip", "path":"$lib/moonstone/samples/TooltipSample"}
+			{"name": "Tooltip", "path":"lib/moonstone/samples/TooltipSample"}
 		]},
-		{"name": "Canvas", "ns":"enyo.sample", "loadPackages":"$lib/canvas $lib/canvas/samples", "samples": [
-			{"name": "Canvas primitives", "path":"$lib/canvas/samples/CanvasPrimitivesSample"},
-			{"name": "Bouncing balls", "path":"$lib/canvas/samples/CanvasBallsSample"}
+		{"name": "Canvas", "ns":"enyo.sample", "loadPackages":"lib/canvas lib/canvas/samples", "samples": [
+			{"name": "Canvas primitives", "path":"lib/canvas/samples/CanvasPrimitivesSample"},
+			{"name": "Bouncing balls", "path":"lib/canvas/samples/CanvasBallsSample"}
 		]},
 		{"name": "iLib (i18n)", "ns": "ilib.sample", "samples": [
-	        {"name": "Locale Info", "path": "$lib/enyo-ilib/samples/LocaleInfo"},
-	        {"name": "Date Formatting", "path": "$lib/enyo-ilib/samples/DateFormatting"},
-	        {"name": "Advanced Date Formatting", "path": "$lib/enyo-ilib/samples/AdvDateFormatting"},
-	        {"name": "Number Formatting", "path": "$lib/enyo-ilib/samples/NumberFormatting"}
+	        {"name": "Locale Info", "path": "lib/enyo-ilib/samples/LocaleInfo"},
+	        {"name": "Date Formatting", "path": "lib/enyo-ilib/samples/DateFormatting"},
+	        {"name": "Advanced Date Formatting", "path": "lib/enyo-ilib/samples/AdvDateFormatting"},
+	        {"name": "Number Formatting", "path": "lib/enyo-ilib/samples/NumberFormatting"}
 	    ]}
 	]
 }

--- a/deploy.json
+++ b/deploy.json
@@ -1,0 +1,6 @@
+{
+	"enyo": "./enyo",
+	"packagejs": "./package.js",
+	"libs": ["./lib/onyx", "./lib/layout", "./lib/canvas", "./lib/enyo-ilib", "./lib/moonstone"],
+	"assets": ["./icon.png", "./index.html", "./assets", "./appinfo.json", "./enyo/samples", "./lib/canvas/samples", "./lib/enyo-ilib/samples", "./lib/layout/contextual/samples", "./lib/layout/easing/samples", "./lib/layout/fittable/samples", "./lib/layout/flex/samples", "./lib/layout/imageview/samples", "./lib/layout/list/samples", "./lib/layout/panels/samples", "./lib/layout/slideable/samples", "./lib/layout/tree/samples", "./lib/moonstone/samples", "./lib/onyx/samples"]
+}


### PR DESCRIPTION
- Remove experimental "Switch to Nightly" feature from app, so we don't need redirection of samples source
- Remove $enyo/$lib macros from samples manifest, per above
- When deleting an addSamples, use removeItem rather than setItem
- Add guards against badly formatted "addSamples" stored in localStorage
- Add deploy.json that copies lib samples
- Add webOS appinfo.json
