### PR TITLE
ENYO-464: Add missing samples to Sampler manifest.

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -110,7 +110,9 @@
 				{"name": "Selectable Item", "path":"lib/moonstone/samples/SelectableItemSample"},
 				{"name": "Radio Item", "path":"lib/moonstone/samples/RadioItemSample"},
 				{"name": "Checkbox Item", "path":"lib/moonstone/samples/CheckboxItemSample"},
-				{"name": "Toggle Item", "path":"lib/moonstone/samples/ToggleItemSample"}
+				{"name": "Toggle Item", "path":"lib/moonstone/samples/ToggleItemSample"},
+				{"name": "Image Item", "path":"lib/moonstone/samples/ImageItemSample"},
+				{"name": "Labeled Text Item", "path":"lib/moonstone/samples/LabeledTextItemSample"}
 			]},
 			{"name": "List", "samples": [
 				{"name": "List Items", "samples": [
@@ -144,6 +146,7 @@
 				{"name": "Date Picker", "path":"lib/moonstone/samples/DatePickerSample"},
 				{"name": "Time Picker", "path":"lib/moonstone/samples/TimePickerSample", "css":"sample"},
 				{"name": "Integer Picker", "path":"lib/moonstone/samples/IntegerPickerSample"},
+				{"name": "Simple Integer Picker", "path":"lib/moonstone/samples/SimpleIntegerPickerSample"},
 				{"name": "Calendar", "path":"lib/moonstone/samples/CalendarSample"}
 			]},
 			{"name": "Popups", "samples": [


### PR DESCRIPTION
### Issue

There were several samples missing from Sampler's manifest; their inclusion will aid in more robust test coverage.
### Fix

We add the missing samples to the manifest.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
