### PR TITLE
ENYO-419: When Moonstone samples are opened in jsFiddle, the Moonstone and Spotlight dependencies are not selected (2.5.1)

### DIFF
--- a/source/App.js
+++ b/source/App.js
@@ -324,7 +324,7 @@ enyo.kind({
 		var form;
 		form = document.createElement("form");
 		form.method = "post";
-		form.action = "http://jsfiddle.net/api/post/enyo/nightly/dependencies/onyx,layout,canvas,g11n/";
+		form.action = "http://jsfiddle.net/api/post/enyo/nightly/dependencies/onyx,layout,canvas,dark,spotlight,ilib/";
 		form.target = "_blank";
 		var el;
 		// JavaScript


### PR DESCRIPTION
Cherry-picking https://github.com/enyojs/sampler/pull/72 into `2.5.1-release`, opening a PR for tracking purposes.
