### PR TITLE
WP-415: sampler side of the commit for enyo-ilib samples

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -175,10 +175,14 @@
 			{"name": "Bouncing balls", "path":"lib/canvas/samples/CanvasBallsSample"}
 		]},
 		{"name": "iLib (i18n)", "ns": "ilib.sample", "samples": [
-	        {"name": "Locale Info", "path": "lib/enyo-ilib/samples/LocaleInfo"},
-	        {"name": "Date Formatting", "path": "lib/enyo-ilib/samples/DateFormatting"},
-	        {"name": "Advanced Date Formatting", "path": "lib/enyo-ilib/samples/AdvDateFormatting"},
-	        {"name": "Number Formatting", "path": "lib/enyo-ilib/samples/NumberFormatting"}
-	    ]}
+	        	{"name": "Locale Info", "path": "lib/enyo-ilib/samples/LocaleInfo"},
+	        	{"name": "Date Formatting", "path": "lib/enyo-ilib/samples/DateFormatting"},
+	        	{"name": "Advanced Date Formatting", "path": "lib/enyo-ilib/samples/AdvDateFormatting"},
+        		{"name": "Number Formatting", "path": "$lib/enyo-ilib/samples/NumberFormatting"},
+			{"name": "Name Parsing", "path": "$lib/enyo-ilib/samples/NameParsing"},
+			{"name": "Name Formatting", "path": "$lib/enyo-ilib/samples/NameFormatting"},
+			{"name": "Address Parsing", "path": "$lib/enyo-ilib/samples/AddressParsing"},
+			{"name": "Address Formatting", "path": "$lib/enyo-ilib/samples/AddressFormatting"}
+	        ]}
 	]
 }

--- a/source/package.js
+++ b/source/package.js
@@ -1,7 +1,7 @@
 enyo.depends(
 	"$lib/layout",
 	"$lib/onyx",
-	"$lib/enyo-ilib",
+	"$lib/enyo-ilib/full-package.js",
 	"$lib/layout/fittable/samples",
 	"$lib/layout/panels/samples",
 	"$lib/layout/list/samples",


### PR DESCRIPTION
Sampler side of the change to add samples of how to parse and format person names, and how to parse and format mailing addresses. This is for stories WP-415 and WP-416. This change was actually done by Pugalendhi Ganesan and Guruprasad KN in LGSI, but they do not have push permissions, so I am pushing it for them.