### PR TITLE
ENYO-946: Add ItemOverlay and ExpandableDataPicker samples.

### DIFF
--- a/assets/manifest.json
+++ b/assets/manifest.json
@@ -112,7 +112,8 @@
 				{"name": "Checkbox Item", "path":"lib/moonstone/samples/CheckboxItemSample"},
 				{"name": "Toggle Item", "path":"lib/moonstone/samples/ToggleItemSample"},
 				{"name": "Image Item", "path":"lib/moonstone/samples/ImageItemSample"},
-				{"name": "Labeled Text Item", "path":"lib/moonstone/samples/LabeledTextItemSample"}
+				{"name": "Labeled Text Item", "path":"lib/moonstone/samples/LabeledTextItemSample"},
+				{"name": "Item Overlay", "path":"lib/moonstone/samples/ItemOverlaySample"}
 			]},
 			{"name": "List", "samples": [
 				{"name": "List Items", "samples": [
@@ -143,6 +144,7 @@
 			]},
 			{"name": "Pickers", "samples": [
 				{"name": "Expandable Picker", "path":"lib/moonstone/samples/ExpandablePickerSample"},
+				{"name": "Expandable Data Picker", "path":"lib/moonstone/samples/ExpandableDataPickerSample"},
 				{"name": "Simple Picker", "path":"lib/moonstone/samples/SimplePickerSample", "css":"sample"},
 				{"name": "Date Picker", "path":"lib/moonstone/samples/DatePickerSample"},
 				{"name": "Time Picker", "path":"lib/moonstone/samples/TimePickerSample", "css":"sample"},


### PR DESCRIPTION
### Issue
We created new samples for `moon.ItemOverlay` and `moon.ExpandableDataPicker`.

### Fix
The manifest has been updated to include these samples.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>